### PR TITLE
Removed code that uses Java reflection to create properties.

### DIFF
--- a/PropertiesProfiling/src/com/dlsc/profiling/EmployeeProfiling.java
+++ b/PropertiesProfiling/src/com/dlsc/profiling/EmployeeProfiling.java
@@ -172,7 +172,7 @@ public class EmployeeProfiling extends Application {
 				employeePropertyAccessor.nameProperty();
 				employeePropertyAccessor.powersProperty();
 				employeePropertyAccessor.supervisorProperty();
-				employeePropertyAccessor.minionsObservables();
+				employeePropertyAccessor.getMinions();
 			}
 			employeePropertyAccessors.add(employeePropertyAccessor);
 		}

--- a/PropertiesProfiling/src/com/dlsc/profiling/EmployeePropertyAccessor.java
+++ b/PropertiesProfiling/src/com/dlsc/profiling/EmployeePropertyAccessor.java
@@ -9,6 +9,8 @@ import javafx.collections.ObservableList;
 
 import java.util.List;
 
+import static com.dlsc.profiling.PropertyAccessors.*;
+
 /**
  * A hybrid domain and model object using the PropertyAccessors interface
  * similar Shadow Fields pattern to save memory. Any fields considered to
@@ -45,7 +47,7 @@ import java.util.List;
  *
  * Created by Carl Dea
  */
-public class EmployeePropertyAccessor implements PropertyAccessors {
+public class EmployeePropertyAccessor {
 
     private Object name;
     private Object powers;
@@ -60,7 +62,7 @@ public class EmployeePropertyAccessor implements PropertyAccessors {
     public final String getName() {return getValue(name); }
     public final void setName(String name) { this.name = setValue(this.name, name); }
     public final StringProperty nameProperty() {
-        name = refProperty("name", name, SimpleStringProperty.class);
+        name = refProperty(this, "name", name, SimpleStringProperty.class);
         return cast(name);
     }
 
@@ -69,7 +71,7 @@ public class EmployeePropertyAccessor implements PropertyAccessors {
     }
 
     public final StringProperty powersProperty() {
-        powers = refProperty("powers", powers, SimpleStringProperty.class);
+        powers = refProperty(this, "powers", powers, SimpleStringProperty.class);
         return cast(powers);
     }
 
@@ -82,7 +84,7 @@ public class EmployeePropertyAccessor implements PropertyAccessors {
     }
 
     public final ObjectProperty<EmployeePropertyAccessor> supervisorProperty() {
-        supervisor = refProperty("supervisor", supervisor, SimpleObjectProperty.class);
+        supervisor = refProperty(this, "supervisor", supervisor, SimpleObjectProperty.class);
         return cast(supervisor);
     }
 
@@ -90,17 +92,12 @@ public class EmployeePropertyAccessor implements PropertyAccessors {
         this.supervisor = setValue(this.supervisor, supervisor);
     }
 
-    public final List<EmployeePropertyAccessor> getMinions() {
-        return minions;
-    }
-
-    public final ObservableList<EmployeePropertyAccessor> minionsObservables() {
+    public final ObservableList<EmployeePropertyAccessor> getMinions() {
         minions = refObservables(minions);
         return cast(minions);
     }
 
     public final void setMinions(List<EmployeePropertyAccessor> minions) {
-        this.minions = minions;
+        getMinions().setAll(minions);
     }
-
 }

--- a/PropertiesProfiling/src/com/dlsc/profiling/EmployeePropertyAccessor.java
+++ b/PropertiesProfiling/src/com/dlsc/profiling/EmployeePropertyAccessor.java
@@ -93,7 +93,7 @@ public class EmployeePropertyAccessor {
     }
 
     public final ObservableList<EmployeePropertyAccessor> getMinions() {
-        minions = refObservables(minions);
+        minions = refObservableList(minions);
         return cast(minions);
     }
 

--- a/PropertiesProfiling/src/com/dlsc/profiling/EmployeePropertyAccessor.java
+++ b/PropertiesProfiling/src/com/dlsc/profiling/EmployeePropertyAccessor.java
@@ -7,9 +7,7 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.ObservableList;
 
-import java.util.ArrayList;
 import java.util.List;
-import static com.dlsc.profiling.PropertyAccessors.registerFields;
 
 /**
  * A hybrid domain and model object using the PropertyAccessors interface
@@ -27,31 +25,23 @@ import static com.dlsc.profiling.PropertyAccessors.registerFields;
  *        // STEP 2: Declare your private member (to hold either a native or property type)
  *        private Object myBrain;
  *
- *        // STEP 3: Choose the fields to be considered properties. Name entries to be the same as member variables!
- *        enum FIELDS {
- *           myBrain
- *        }
- *
- *        // STEP 4: Register the fields to be shadowed.
- *        static {
- *           registerFields(MyClass.class, FIELDS.values());
- *        }
- *
- *        // STEP 5: Use the PropertyAccessor interface API for getters/setters/property methods.
+ *        // STEP 3: Use the PropertyAccessor interface API for getters/setters/property methods.
  *        public final String getMyBrain() {
- *           return getValue(FIELDS.myBrain, "");
+ *           return getValue(myBrain);
  *        }
  *        public final void setMyBrain((String myBrain) {
- *           setValue(FIELDS.myBrain, myBrain);
+ *           this.myBrain = setValue(this.myBrain, myBrain);
  *        }
  *        public final StringProperty myBrainProperty() {
- *           return refProperty(FIELDS.myBrain, SimpleStringProperty.class, String.class);
+ *           myBrain = refProperty(myBrain, SimpleStringProperty.class);
+ *           return cast(myBrain);
  *        }
  *
  *        // .. The rest of the class definition
  *     }
  *     </code>
  * </pre>
+ *
  *
  * Created by Carl Dea
  */
@@ -60,70 +50,57 @@ public class EmployeePropertyAccessor implements PropertyAccessors {
     private Object name;
     private Object powers;
     private Object supervisor;
-    private Object minions;
-
-    enum FIELDS {
-        name,
-        powers,
-        supervisor,
-        minions
-    }
-
-    static {
-        // register fields one time.
-        // (Warning: enum's ordinal value is reassigned and index number)
-        registerFields(EmployeePropertyAccessor.class, FIELDS.values());
-    }
+    private List<EmployeePropertyAccessor> minions;
 
     public EmployeePropertyAccessor(String name, String powers) {
         setName(name);
         setPowers(powers);
     }
 
-    public final String getName() {
-        return getValue(FIELDS.name, "");
-    }
-    public final void setName(String name) {
-        setValue(FIELDS.name, name);
-    }
+    public final String getName() {return getValue(name); }
+    public final void setName(String name) { this.name = setValue(this.name, name); }
     public final StringProperty nameProperty() {
-        return refProperty(FIELDS.name, SimpleStringProperty.class, String.class);
+        name = refProperty("name", name, SimpleStringProperty.class);
+        return cast(name);
     }
 
     public String getPowers() {
-        return getValue(FIELDS.powers, "");
+        return getValue(powers);
     }
 
     public final StringProperty powersProperty() {
-        return refProperty(FIELDS.powers, SimpleStringProperty.class, String.class);
+        powers = refProperty("powers", powers, SimpleStringProperty.class);
+        return cast(powers);
     }
 
     public final void setPowers(String powers) {
-        setValue(FIELDS.powers, powers);
+        this.powers = setValue(this.powers, powers);
     }
 
     public final EmployeePropertyAccessor getSupervisor() {
-        return getValue(FIELDS.supervisor, null);
+        return getValue(supervisor);
     }
 
     public final ObjectProperty<EmployeePropertyAccessor> supervisorProperty() {
-        return refProperty(FIELDS.supervisor, SimpleObjectProperty.class, EmployeePropertyAccessor.class);
+        supervisor = refProperty("supervisor", supervisor, SimpleObjectProperty.class);
+        return cast(supervisor);
     }
 
     public final void setSupervisor(EmployeePropertyAccessor supervisor) {
-        setValue(FIELDS.supervisor, supervisor);
+        this.supervisor = setValue(this.supervisor, supervisor);
     }
 
     public final List<EmployeePropertyAccessor> getMinions() {
-        return getValues(FIELDS.minions, new ArrayList<>());
+        return minions;
     }
 
     public final ObservableList<EmployeePropertyAccessor> minionsObservables() {
-        return refObservables(FIELDS.minions);
+        minions = refObservables(minions);
+        return cast(minions);
     }
 
     public final void setMinions(List<EmployeePropertyAccessor> minions) {
-        setValues(FIELDS.minions, minions);
+        this.minions = minions;
     }
 
 }

--- a/PropertiesProfiling/src/com/dlsc/profiling/PropertyAccessors.java
+++ b/PropertiesProfiling/src/com/dlsc/profiling/PropertyAccessors.java
@@ -30,35 +30,26 @@ import java.util.Map;
  * The following example is what a user of the API will need to do:
  * <pre>
  *     <code>
+ . The rest of the class definition
  *        // STEP 1: Implement the interface PropertyAccessors
  *     public class MyClass implements PropertyAccessors {
  *
  *        // STEP 2: Declare your private member (to hold either a native or property type)
  *        private Object myBrain;
  *
- *        // STEP 3: Choose the fields to be considered properties. Name entries to be the same as member variables!
- *        enum FIELDS {
- *           myBrain
- *        }
- *
- *        // STEP 4: Register the fields to be shadowed.
- *        static {
- *           registerFields(MyClass.class, FIELDS.values());
- *        }
- *
- *        // STEP 5: Use the PropertyAccessor interface API for getters/setters/property methods.
+ *        // STEP 3: Use the PropertyAccessor interface API for getters/setters/property methods.
  *        public final String getMyBrain() {
- *           return getValue(FIELDS.myBrain, "");
+ *           return getValue(myBrain);
  *        }
  *        public final void setMyBrain((String myBrain) {
- *           setValue(FIELDS.myBrain, myBrain);
+ *           this.myBrain = setValue(this.myBrain, myBrain);
  *        }
  *        public final StringProperty myBrainProperty() {
- *           return refProperty(FIELDS.myBrain, SimpleStringProperty.class, String.class);
+ *           myBrain = refProperty(myBrain, SimpleStringProperty.class);
+ *           return cast(myBrain);
  *        }
  *
  *        // .. The rest of the class definition
- *     }
  *     </code>
  * </pre>
  *
@@ -105,11 +96,11 @@ public interface PropertyAccessors {
 
     /**
      *
-     * @param name
-     * @param p
-     * @param propertyClass
-     * @param <T>
-     * @return
+     * @param name Name of the property
+     * @param p potential callers attribute value (raw or a property)
+     * @param propertyClass The concreate JavaFX property class such as SimpleStringProperty.class
+     * @param <T> The Property object for the caller to set as.
+     * @return The return of the property object.
      */
     default <T> T refProperty(String name, Object p, Class propertyClass) {
         Property prop = null;

--- a/PropertiesProfiling/src/com/dlsc/profiling/PropertyAccessors.java
+++ b/PropertiesProfiling/src/com/dlsc/profiling/PropertyAccessors.java
@@ -168,7 +168,7 @@ public class PropertyAccessors {
 //                SimpleSetProperty
 //
 
-    public static <T> ObservableList<T> refObservables(List list) {
+    public static <T> ObservableList<T> refObservableList(List list) {
 
         if (list == null) {
             list = FXCollections.observableArrayList();
@@ -191,7 +191,7 @@ public class PropertyAccessors {
 
         return cast(map);
     }
-    public static <E> ObservableSet<E> refObservableMap(Set<E> set) {
+    public static <E> ObservableSet<E> refObservableSet(Set<E> set) {
 
         if (set == null) {
             return FXCollections.observableSet(new HashSet<>());

--- a/PropertiesProfiling/src/com/dlsc/profiling/PropertyAccessors.java
+++ b/PropertiesProfiling/src/com/dlsc/profiling/PropertyAccessors.java
@@ -5,34 +5,43 @@ import javafx.beans.property.*;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
+import javafx.collections.ObservableSet;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
- * The PropertyAccessors interface provides default methods to support the similar
- * capability of the shadow fields pattern. To save memory object values don't have to be
- * wrapped into a Property object when using getters and setters, however when
- * calling property type methods values will be wrapped into a property object.
- *
- * #Version 1 no attributes, but a map to hold values. It was expensive.
- * #Version 2 Centralized a map to hold values.
- * #Version 3 used to use reflection to index fields and dynamically create property types.
- * #Version 4 now removes the need of reflection. Also, added a convenience
+ * The PropertyAccessors is a static utility class that provides default methods to
+ * support the similar capability of the shadow fields pattern. To save memory object
+ * values don't have to be wrapped into a Property object when using getters and
+ * setters, however when calling property type methods values will be wrapped into a
+ * property object.
+ * <pre>
+ * Version notes:
+ *  Version 1 No private attributes, but a map to hold values. It was expensive.
+ *  Version 2 Centralized a map to hold values.
+ *  Version 3 Uses reflection to generate index fields and dynamically create property types.
+ *  Version 4 Removes the need of reflection. Also, added a convenience method to cast.
+ *  Version 5 Converted this interface into a static utility class.
+ * </pre>
  *
  * This API allows the developer to easily specify fields without having boilerplate code
- * when creating shadow fields to save memory. Any fields considered to
- * be a raw object type or JavaFX Property will declare a private member
- * as an Object. Next, the developer will declare any enum with entries
- * named the same as the private member variable names. After the fields have been
- * declared simply register the fields using the static method registerFields().
+ * when creating shadow fields to save memory. Any fields considered to be a raw object type
+ * or JavaFX Property will declare a private member as an Object. Next, the developer will
+ * declare any enum with entries named the same as the private member variable names. After
+ * the fields have been declared simply register the fields using the static method
+ * registerFields().
  *
  * The following example is what a user of the API will need to do:
+ *
  * <pre>
  *     <code>
  . The rest of the class definition
- *        // STEP 1: Implement the interface PropertyAccessors
- *     public class MyClass implements PropertyAccessors {
+ *        // STEP 1: static import the PropertyAccessors utility class
+ *     import static com.carlfx.PropertyAccessors.*;
+ *     public class MyClass  {
  *
  *        // STEP 2: Declare your private member (to hold either a native or property type)
  *        private Object myBrain;
@@ -55,14 +64,15 @@ import java.util.Map;
  *
  * Created by Carl Dea
  */
-public interface PropertyAccessors {
+public class PropertyAccessors {
+    private PropertyAccessors() {}
     /**
      * Convenience function to reduce boiler plate of casting objects to return an object.
      * @param object The object to cast.
      * @param <T> The return object of the type T.
      * @return Object of type T
      */
-    default <T> T cast(Object object) {
+    public static <T> T cast(Object object) {
         return (T) object;
     }
 
@@ -72,54 +82,73 @@ public interface PropertyAccessors {
      * @param <T> The raw value is returned.
      * @return Object value raw type.
      */
-    default <T> T getValue(Object p) {
+    public static <T> T getValue(Object p) {
         return (T) ((p instanceof Property) ? ((Property) p).getValue(): p);
     }
 
     /**
-     * This will return a Property or Raw object value for the caller to set.
+     * This method will return a Property or raw object type value for the caller to set.
+     * <pre>
+     *     The following is how to call the setValue() method. Remember to set the attribute to the setValue()
+     *     method's return value.
+     *     <code>
+     *        public final void setMyBrain((String myBrain) {
+     *           this.myBrain = setValue(this.myBrain, myBrain);
+     *        }
+     *     </code>
+     * </pre>
      * @param p The potential property object.
      * @param value The raw value to set. If underlying object is a property the raw value will be set into.
      * @param <T> The value type either raw or a property.
      * @return A property or raw object is returned for the caller to set. Important that the caller sets
      * the private member to the return value.
      */
-    default <T> T setValue(Object p, Object value) {
+    public static <T> T setValue(Object p, Object value) {
         if (p instanceof Property) {
             ((Property)p).setValue(value);
             return (T) p;
         } else {
             return (T) value;
         }
-
     }
 
     /**
-     *
+     * This method will return a Property type value for the caller to set.
+     * <pre>
+     *     The following is how to call the refProperty() method. Remember to set the attribute
+     *     to the refProperty() method's return value. A convenience method to cast the property as
+     *     the return type (syntactic sugar).
+     *     <code>
+     *        public final StringProperty myBrainProperty() {
+     *           myBrain = refProperty(myBrain, SimpleStringProperty.class);
+     *           return cast(myBrain);
+     *        }
+     *     </code>
+     * </pre>
      * @param name Name of the property
      * @param p potential callers attribute value (raw or a property)
      * @param propertyClass The concreate JavaFX property class such as SimpleStringProperty.class
      * @param <T> The Property object for the caller to set as.
      * @return The return of the property object.
      */
-    default <T> T refProperty(String name, Object p, Class propertyClass) {
+    public static <T> T refProperty(Object bean, String name, Object p, Class propertyClass) {
         Property prop = null;
         if (p == null || !(p instanceof Property)) {
             // create a property object
             if (SimpleBooleanProperty.class == propertyClass) {
-                prop = new SimpleBooleanProperty(this, name);
+                prop = new SimpleBooleanProperty(bean, name);
             } else if (SimpleDoubleProperty.class == propertyClass) {
-                prop = new SimpleDoubleProperty(this, name);
+                prop = new SimpleDoubleProperty(bean, name);
             } else if (SimpleFloatProperty.class == propertyClass) {
-                prop = new SimpleFloatProperty(this, name);
+                prop = new SimpleFloatProperty(bean, name);
             } else if (SimpleIntegerProperty.class == propertyClass) {
-                prop = new SimpleIntegerProperty(this, name);
+                prop = new SimpleIntegerProperty(bean, name);
             } else if (SimpleLongProperty.class == propertyClass) {
-                prop = new SimpleLongProperty(this, name);
+                prop = new SimpleLongProperty(bean, name);
             } else if (SimpleObjectProperty.class == propertyClass) {
-                prop = new SimpleObjectProperty(this, name);
+                prop = new SimpleObjectProperty(bean, name);
             } else if (SimpleStringProperty.class == propertyClass) {
-                prop = new SimpleStringProperty(this, name);
+                prop = new SimpleStringProperty(bean, name);
             } else {
                 throw new RuntimeException("Unsupported concrete Property class " + propertyClass.getName());
             }
@@ -139,7 +168,7 @@ public interface PropertyAccessors {
 //                SimpleSetProperty
 //
 
-    default <T> ObservableList<T> refObservables(List list) {
+    public static <T> ObservableList<T> refObservables(List list) {
 
         if (list == null) {
             list = FXCollections.observableArrayList();
@@ -147,10 +176,10 @@ public interface PropertyAccessors {
             list = FXCollections.observableArrayList(list);
         }
 
-        return (ObservableList<T>) list;
+        return cast(list);
     }
 
-    default <K,V> ObservableMap<K, V> refObservableMap(Map<K,V> map) {
+    public static <K,V> ObservableMap<K, V> refObservableMap(Map<K,V> map) {
 
         if (map == null) {
             return FXCollections.observableHashMap();
@@ -160,7 +189,18 @@ public interface PropertyAccessors {
             return newMap;
         }
 
-        return (ObservableMap<K, V>) map;
+        return cast(map);
+    }
+    public static <E> ObservableSet<E> refObservableMap(Set<E> set) {
+
+        if (set == null) {
+            return FXCollections.observableSet(new HashSet<>());
+        } else if (! (set instanceof ObservableSet)) {
+            ObservableSet<E> newSet = FXCollections.observableSet(new HashSet<>());
+            newSet.addAll(set);
+            return newSet;
+        }
+        return cast(set);
     }
 
 }


### PR DESCRIPTION
The only files altered were PropertyAccessors.java and EmployeePropertyAccessor.java
An example of the user of the API:

```
public class EmployeePropertyAccessor implements PropertyAccessors {
    private Object name;
    private Object powers;
    private Object supervisor;
    private List<EmployeePropertyAccessor> minions;

    public EmployeePropertyAccessor(String name, String powers) {
        setName(name);
        setPowers(powers);
    }

    public final String getName() {
        return getValue(name); 
    }
    public final void setName(String name) { 
        this.name = setValue(this.name, name); 
    }
    public final StringProperty nameProperty() {
        name = refProperty("name", name, SimpleStringProperty.class);
        return cast(name);
    }
// Rest of the code 
}
```
